### PR TITLE
Remove redundant hyperx dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,5 @@
     "tape": "^4.2.0",
     "virtual-dom": "^2.1.1"
   },
-  "dependencies": {
-    "hyperx": "^1.0.4"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
It seems hyperx is instead a devDependency (rather than a true dependency)